### PR TITLE
Set option print-success to false

### DIFF
--- a/process.incremental-track
+++ b/process.incremental-track
@@ -12,4 +12,4 @@
 grep -o "(set-info :status \(sat\|unsat\|unknown\))" "$1"|sed 's/(set-info :status \(.*\))/\1/'
 echo "--- BENCHMARK BEGINS HERE ---"
 ulimit -s 131072
-./scrambler -seed "$2" < "$1"
+./scrambler -incremental true -seed "$2" < "$1"

--- a/test/extensions/non-smtcomp/expect/test-non-smtcomp.0.non-smtcomp.expect
+++ b/test/extensions/non-smtcomp/expect/test-non-smtcomp.0.non-smtcomp.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (set-option :print-success false)
 (declare-fun x () Bool)

--- a/test/extensions/non-smtcomp/expect/test-non-smtcomp.1234.non-smtcomp.expect
+++ b/test/extensions/non-smtcomp/expect/test-non-smtcomp.1234.non-smtcomp.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (set-option :print-success false)
 (declare-fun x1 () Bool)

--- a/test/extensions/z3/expect/test-z3.0.z3.expect
+++ b/test/extensions/z3/expect/test-z3.0.z3.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-sort |T@U| 0)
 (declare-fun UOrdering2 (|T@U| |T@U|) Bool)

--- a/test/extensions/z3/expect/test-z3.1234.z3.expect
+++ b/test/extensions/z3/expect/test-z3.1234.z3.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-sort x2 0)
 (declare-fun x8 () Bool)

--- a/test/smt-comp/expect/test-all.0.model-val.expect
+++ b/test/smt-comp/expect/test-all.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic AUFBVDTNIRA)
 (assert true)

--- a/test/smt-comp/expect/test-all.0.single.expect
+++ b/test/smt-comp/expect/test-all.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic AUFBVDTNIRA)
 (assert true)
 (check-sat)

--- a/test/smt-comp/expect/test-all.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-all.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic AUFBVDTNIRA)
 (assert (! true :named smtcomp1))

--- a/test/smt-comp/expect/test-all.1234.model-val.expect
+++ b/test/smt-comp/expect/test-all.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic AUFBVDTNIRA)
 (assert true)

--- a/test/smt-comp/expect/test-all.1234.single.expect
+++ b/test/smt-comp/expect/test-all.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic AUFBVDTNIRA)
 (assert true)
 (check-sat)

--- a/test/smt-comp/expect/test-all.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-all.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic AUFBVDTNIRA)
 (assert (! true :named smtcomp1))

--- a/test/smt-comp/expect/test-pattern.0.model-val.expect
+++ b/test/smt-comp/expect/test-pattern.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic UF)
 (declare-sort A 0)

--- a/test/smt-comp/expect/test-pattern.0.single.expect
+++ b/test/smt-comp/expect/test-pattern.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic UF)
 (declare-sort A 0)
 (declare-fun a () A)

--- a/test/smt-comp/expect/test-pattern.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-pattern.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic UF)
 (declare-sort A 0)

--- a/test/smt-comp/expect/test-pattern.1234.model-val.expect
+++ b/test/smt-comp/expect/test-pattern.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic UF)
 (declare-sort x3 0)

--- a/test/smt-comp/expect/test-pattern.1234.single.expect
+++ b/test/smt-comp/expect/test-pattern.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic UF)
 (declare-sort x3 0)
 (declare-fun x4 () x3)

--- a/test/smt-comp/expect/test-pattern.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-pattern.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic UF)
 (declare-sort x3 0)

--- a/test/smt-comp/expect/test-reserved-words.0.model-val.expect
+++ b/test/smt-comp/expect/test-reserved-words.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun |BINARY| () Bool)

--- a/test/smt-comp/expect/test-reserved-words.0.single.expect
+++ b/test/smt-comp/expect/test-reserved-words.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun |BINARY| () Bool)
 (declare-fun |DECIMAL| () Bool)

--- a/test/smt-comp/expect/test-reserved-words.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-reserved-words.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun |BINARY| () Bool)

--- a/test/smt-comp/expect/test-reserved-words.1234.model-val.expect
+++ b/test/smt-comp/expect/test-reserved-words.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x9 () Bool)

--- a/test/smt-comp/expect/test-reserved-words.1234.single.expect
+++ b/test/smt-comp/expect/test-reserved-words.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x9 () Bool)
 (declare-fun x12 () Bool)

--- a/test/smt-comp/expect/test-reserved-words.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-reserved-words.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x9 () Bool)

--- a/test/smt-comp/expect/test-shadowing-1.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-1.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-1.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-1.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (let ((x true)) x))

--- a/test/smt-comp/expect/test-shadowing-1.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-1.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-1.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-1.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-1.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-1.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert x1)

--- a/test/smt-comp/expect/test-shadowing-1.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-1.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-2.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-2.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-2.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-2.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (let ((x x)) x))

--- a/test/smt-comp/expect/test-shadowing-2.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-2.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-2.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-2.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-2.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-2.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert x1)

--- a/test/smt-comp/expect/test-shadowing-2.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-2.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-3.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-3.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-3.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-3.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (let ((x x)) (let ((x x)) x)))

--- a/test/smt-comp/expect/test-shadowing-3.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-3.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-3.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-3.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-3.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-3.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert x1)

--- a/test/smt-comp/expect/test-shadowing-3.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-3.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-4.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-4.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-4.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-4.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (let ((x x) (y x)) true))

--- a/test/smt-comp/expect/test-shadowing-4.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-4.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-4.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-4.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-4.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-4.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert (let ((x2 x1) (x1 x1)) true))

--- a/test/smt-comp/expect/test-shadowing-4.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-4.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-5.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-5.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-5.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-5.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (let ((x x) (y x)) x))

--- a/test/smt-comp/expect/test-shadowing-5.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-5.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-5.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-5.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-5.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-5.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert x1)

--- a/test/smt-comp/expect/test-shadowing-5.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-5.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-6.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-6.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-6.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-6.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x () Bool)
 (assert (forall ((x Int) (x Int)) (= x x)))

--- a/test/smt-comp/expect/test-shadowing-6.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-6.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-6.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-6.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-6.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-6.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x1 () Bool)
 (assert x1)

--- a/test/smt-comp/expect/test-shadowing-6.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-6.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-7.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-7.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (push 1)

--- a/test/smt-comp/expect/test-shadowing-7.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-7.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (push 1)
 (declare-fun x () Bool)

--- a/test/smt-comp/expect/test-shadowing-7.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-7.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (push 1)

--- a/test/smt-comp/expect/test-shadowing-7.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-7.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (push 1)

--- a/test/smt-comp/expect/test-shadowing-7.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-7.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (push 1)
 (declare-fun x1 () Bool)

--- a/test/smt-comp/expect/test-shadowing-7.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-7.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (push 1)

--- a/test/smt-comp/expect/test-shadowing-8.0.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-8.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (define-fun x ((y Int) (y Int)) Bool (= y y))

--- a/test/smt-comp/expect/test-shadowing-8.0.single.expect
+++ b/test/smt-comp/expect/test-shadowing-8.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (define-fun x ((y Int) (y Int)) Bool (= y y))
 (assert (x 0 0))

--- a/test/smt-comp/expect/test-shadowing-8.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-8.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (define-fun x ((y Int) (y Int)) Bool (= y y))

--- a/test/smt-comp/expect/test-shadowing-8.1234.model-val.expect
+++ b/test/smt-comp/expect/test-shadowing-8.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (define-fun x2 ((x1 Int) (x1 Int)) Bool (= x1 x1))

--- a/test/smt-comp/expect/test-shadowing-8.1234.single.expect
+++ b/test/smt-comp/expect/test-shadowing-8.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (define-fun x2 ((x1 Int) (x1 Int)) Bool (= x1 x1))
 (assert (x2 0 0))

--- a/test/smt-comp/expect/test-shadowing-8.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-shadowing-8.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (define-fun x2 ((x1 Int) (x1 Int)) Bool (= x1 x1))

--- a/test/smt-comp/expect/test-string-escapes.0.model-val.expect
+++ b/test/smt-comp/expect/test-string-escapes.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (check-sat)

--- a/test/smt-comp/expect/test-string-escapes.0.single.expect
+++ b/test/smt-comp/expect/test-string-escapes.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (check-sat)
 (exit)

--- a/test/smt-comp/expect/test-string-escapes.0.unsat-core.expect
+++ b/test/smt-comp/expect/test-string-escapes.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (check-sat)

--- a/test/smt-comp/expect/test-string-escapes.1234.model-val.expect
+++ b/test/smt-comp/expect/test-string-escapes.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (check-sat)

--- a/test/smt-comp/expect/test-string-escapes.1234.single.expect
+++ b/test/smt-comp/expect/test-string-escapes.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (check-sat)
 (exit)

--- a/test/smt-comp/expect/test-string-escapes.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test-string-escapes.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (check-sat)

--- a/test/smt-comp/expect/test.0.model-val.expect
+++ b/test/smt-comp/expect/test.0.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun c0 () Bool)

--- a/test/smt-comp/expect/test.0.single.expect
+++ b/test/smt-comp/expect/test.0.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun c0 () Bool)
 (declare-fun E0 () Bool)

--- a/test/smt-comp/expect/test.0.unsat-core.expect
+++ b/test/smt-comp/expect/test.0.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun c0 () Bool)

--- a/test/smt-comp/expect/test.1234.model-val.expect
+++ b/test/smt-comp/expect/test.1234.model-val.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-fun x3 () Bool)

--- a/test/smt-comp/expect/test.1234.single.expect
+++ b/test/smt-comp/expect/test.1234.single.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-logic ALL)
 (declare-fun x3 () Bool)
 (declare-fun x2 () Bool)

--- a/test/smt-comp/expect/test.1234.unsat-core.expect
+++ b/test/smt-comp/expect/test.1234.unsat-core.expect
@@ -1,3 +1,4 @@
+(set-option :print-success false)
 (set-option :produce-unsat-cores true)
 (set-logic ALL)
 (declare-fun x3 () Bool)


### PR DESCRIPTION
This adds the line
```
(set-option :print-success false)
```
to the beginning of the scrambled output in every track, except for the incremental track.