### PR TITLE
Docker-Build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 CXX = g++ -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
 CXXFLAGS = -g -O3
-LDFLAGS = -g -static
+LDFLAGS = -g
 
 OBJECTS = scrambler.o \
 	  parser.o \
 	  lexer.o
+
+PREPROCESSORS = \
+	SMT-COMP-2021-single-query-scrambler.tar.gz \
+	SMT-COMP-2021-incremental-scrambler.tar.gz \
+	SMT-COMP-2021-unsat-core-scrambler.tar.gz \
+	SMT-COMP-2021-model-validation-scrambler.tar.gz
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
@@ -25,32 +31,35 @@ test: scrambler
 
 # targets to prepare StarExec preprocessors
 
-SMT-COMP-2020-single-query-scrambler.tar.xz: scrambler
+SMT-COMP-2021-single-query-scrambler.tar.gz: scrambler
 	cp process.single-query-challenge-track process
-	tar -cJf $@ process scrambler
+	tar -czf $@ process scrambler
 	rm process
 
-SMT-COMP-2020-incremental-scrambler.tar.xz: scrambler
+SMT-COMP-2021-incremental-scrambler.tar.gz: scrambler
 	cp process.incremental-track process
-	tar -cJf $@ process scrambler
+	tar -czf $@ process scrambler
 	rm process
 
-SMT-COMP-2020-unsat-core-scrambler.tar.xz: scrambler
+SMT-COMP-2021-unsat-core-scrambler.tar.gz: scrambler
 	cp process.unsat-core-track process
-	tar -cJf $@ process scrambler
+	tar -czf $@ process scrambler
 	rm process
 
-SMT-COMP-2020-model-validation-scrambler.tar.xz: scrambler
+SMT-COMP-2021-model-validation-scrambler.tar.gz: scrambler
 	cp process.model-val-track process
-	tar -cJf $@ process scrambler
+	tar -czf $@ process scrambler
 	rm process
 
 .PHONY: all clean cleanall
 
-all: scrambler SMT-COMP-2020-single-query-scrambler.tar.xz SMT-COMP-2020-incremental-scrambler.tar.xz SMT-COMP-2020-unsat-core-scrambler.tar.xz SMT-COMP-2020-model-validation-scrambler.tar.xz
+all: scrambler $(PREPROCESSORS)
 
 clean:
 	rm -f $(OBJECTS) lexer.cpp lexer.h parser.cpp parser.h parser.output
 
 cleanall: clean
-	rm -f scrambler SMT-COMP-2020-single-query-scrambler.tar.xz SMT-COMP-2020-incremental-scrambler.tar.xz SMT-COMP-2020-unsat-core-scrambler.tar.xz SMT-COMP-2020-model-validation-scrambler.tar.xz
+	rm -f scrambler $(PREPROCESSORS)
+
+dist: $(PREPROCESSORS)
+	cp $(PREPROCESSORS) /dist


### PR DESCRIPTION
This is the other part corresponding to the pull-request of the postprocessor.

no -static anymore (we compile it on centos-7 image)
updated file names to 2021
add the dist rule we need for docker build
produce .tar.gz files (which can be directly uploaded)